### PR TITLE
Revive of PR #1686.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -51,6 +51,7 @@ spec: webidl;
         text: resolve;
 
 spec:csp-next; type:dfn; text:enforced
+spec:urlpattern; type:dfn; text:match
 </pre>
 
 <pre class="anchors">
@@ -132,11 +133,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         text: storage key; url: storage-key
         text: obtain a storage key; url: obtain-a-storage-key
         text: storage key/equals; url: storage-key-equals
-
-spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
-    type: dfn
-        text: match; for: urlpattern; url: match
-
 </pre>
 
 <pre class="biblio">
@@ -3267,7 +3263,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
               1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-              1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
               1. Return |rule|'s {{RouterRule/source}}.
 
       1. Return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3108,7 +3108,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
-          1. If running [=Get Router Source=] with |registration|'s <a>active worker</a> and |request| returns "network", return null.
+          1. If running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1578,7 +1578,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |routerRules| be a list of {{RouterRule}} dictionaries.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1.  For each |rule| of |rules|:
-            1. If running [=VerifyRouterRule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
+            1. If running [=Verify Router Rule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
             1. Append |rule| to |routerRules|.
         1. Set [=/service worker=]'s [=service worker/list of router rules=] to |routerRules|.
 
@@ -3108,7 +3108,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
-          1. If running [=GetRouterSource=] with |registration|'s <a>active worker</a> and |request| returns "network", return null.
+          1. If running [=Get Router Source=] with |registration|'s <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.
@@ -3218,7 +3218,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="parse-urlpattern-algorithm"><dfn>ParseURLPattern</dfn></h3>
+    <h3 id="parse-urlpattern-algorithm"><dfn>Parse URL Pattern</dfn></h3>
       : Input
       :: |rawPattern|, a [=string=]
       :: |serviceWorker|, a [=/service worker=]
@@ -3230,7 +3230,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="verify-router-rule-algorithm"><dfn>VerifyRouterRule</dfn></h3>
+    <h3 id="verify-router-rule-algorithm"><dfn>Verify Router Rule</dfn></h3>
 
       : Input
       :: |rule|, a {{RouterRule}}
@@ -3240,7 +3240,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+      1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.
@@ -3249,7 +3249,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="get-router-source-algorithm"><dfn>GetRouterSource</dfn></h3>
+    <h3 id="get-router-source-algorithm"><dfn>Get Router Source</dfn></h3>
       : Input
       :: |serviceWorker|, a [=/service worker=]
       :: |request|, a [=/request=]
@@ -3259,7 +3259,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], continue.
           1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
           1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. Return |rule|["{{RouterRule/source}}"].
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3244,8 +3244,9 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
+      1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serivceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
+      1. Let |pattern| be the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -133,6 +133,22 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         text: obtain a storage key; url: obtain-a-storage-key
         text: storage key/equals; url: storage-key-equals
 
+spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
+    type: dfn
+        text: parse; for: urlpattern; url: parse-a-pattern-string
+        text: component; for: urlpattern; url: component
+        text: match; for: urlpattern; url: match
+        text: protocol component; for: urlpattern; url: urlpattern-protocol-component
+        text: username component; for: urlpattern; url: urlpattern-username-component
+        text: password component; for: urlpattern; url: urlpattern-password-component
+        text: hostname component; for: urlpattern; url: urlpattern-hostname-component
+        text: port component; for: urlpattern; url: urlpattern-port-component
+        text: pathname component; for: urlpattern; url: urlpattern-pathname-component
+        text: search component; for: urlpattern; url: urlpattern-search-component
+        text: hash component; for: urlpattern; url: urlpattern-hash-component
+        text: pattern string; for: urlpattern-component; url: component-pattern-string
+        text: type; for: urlpattern-part; url: part-type
+
 </pre>
 
 <pre class="biblio">
@@ -206,6 +222,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
     A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
+
+    A [=/service worker=] has an associated <dfn>static router rules object</dfn>. It is initially unset.
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
@@ -1546,6 +1564,46 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section>
+    <h3 id="installevent-interface">{{InstallEvent}}</h3>
+
+    <pre class="idl">
+      [Exposed=ServiceWorker]
+      interface InstallEvent : ExtendableEvent {
+        Promise&lt;undefined&gt; registerRouter((RouterRule or sequence&lt;RouterRule&gt;) rules);
+      };
+
+      dictionary RouterRule {
+        required RouterCondition condition;
+        required RouterSourceEnum source;
+      };
+
+      dictionary RouterCondition {
+        USVString urlPattern;
+      };
+
+      enum RouterSourceEnum { "network" };
+    </pre>
+
+    Each {{RouterCondition/urlPattern}} object has an associated <dfn>URLPattern</dfn>, a {{URLPattern}}, which is initially unset.
+
+    <section>
+      <h4 id="register-router-method">{{InstallEvent/registerRouter(rules)|event.registerRouter(rules)}}</h4>
+
+      {{InstallEvent/registerRouter(rules)}} registers this service worker the rules to offload simple tasks that the fetch handler does.
+
+      <dfn method for="InstallEvent"><code>registerRouter(|rules|)</code></dfn> method *must* run these steps:
+
+        1. Let |routerRules| be a list of {{RouterRule}} dictionaries.
+        1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
+        1.  for each |rule| in |rules|:
+            1. If running [=VerifyRouterRule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
+            1. Append |rule| to |routerRules|.
+        1. Set [=/service worker=]'s [=static router rules object=] to |routerRules|.
+
+    </section>
+  </section>
+
+  <section>
     <h3 id="fetchevent-interface">{{FetchEvent}}</h3>
 
     <pre class="idl">
@@ -2822,7 +2880,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Set |installFailed| to true.
           1. Else:
               1. [=Queue a task=] |task| on |installingWorker|'s [=event loop=] using the [=DOM manipulation task source=] to run the following steps:
-                  1. Let |e| be the result of <a>creating an event</a> with {{ExtendableEvent}}.
+                  1. Let |e| be the result of <a>creating an event</a> with {{InstallEvent}}.
                   1. Initialize |e|’s {{Event/type}} attribute to {{install!!event}}.
                   1. <a>Dispatch</a> |e| at |installingWorker|'s [=service worker/global object=].
                   1. *WaitForAsynchronousExtensions*: Run the following substeps <a>in parallel</a>:
@@ -3067,6 +3125,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
+      1. Else if |registration|'s <a>active worker</a>'s [=static router rules object=] is set:
+          1. If running [=GetRouterSource=] algorithm with [=static router rules object=] and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.
@@ -3173,6 +3233,78 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           2. Return a [=network error=].
       1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
       1. Return |response|.
+  </section>
+
+  <section algorithm>
+    <h3 id="verify-router-rule-algorithm"><dfn>VerifyRouterRule</dfn></h3>
+
+      : Input
+      :: |rule|, a {{RouterRule}}
+      :: |serviceWorker|, a [=/service worker=]
+      : Output
+      :: a boolean
+
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] is the empty string, return false.
+      1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+      1. If |rawPattern| is a [=string=], then:
+        1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
+        1. Set |pattern| to the result of constructing a {{URLPattern}} using the {{URLPattern/URLPattern(input, baseURL)}} constructor steps given |rawPattern| and |baseURL|. If those steps throw, catch the exception and return false.
+      1. Otherwise, if |rawPattern| is {{URLPatternInit}}:
+        1. Set |pattern| to the result of constructing a {{URLPattern}} using the {{URLPattern/URLPattern(input)}} constructor steps given |rawPattern|. If those steps throw, catch the exception and return false.
+      1. Otherwise, return false.
+      1. If running the [=VerifyURLPattern=] algorithm with |pattern| returns false, return false.
+      1. Set |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated {{URLPattern}} to |pattern|.
+      1. Return true.
+  </section>
+
+  <section algorithm>
+    <h3 id="verify-urlpattern-algorithm"><dfn>VerifyURLPattern</dfn></h3>
+
+    : Input
+    :: |pattern|, a {{URLPattern}}
+    : Output
+    :: a boolean
+
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/protocol component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/username component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/password component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/hostname component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/port component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/pathname component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/search component=] returns false, return false.
+    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/hash component=] returns false, return false.
+    1. Return true.
+  </section>
+
+  <section algorithm>
+    <h3 id="verify-urlpattern-component-algorithm"><dfn>VerifyURLPatternComponent</dfn></h3>
+
+      : Input
+      :: |component|, a [=component=].
+      : Output
+      :: a boolean
+
+      1. Let |parts| be a result of [=urlpattern/parsing=] |component|'s associated [=urlpattern-component/pattern string=].
+      1. [=list/For each=] |part| of |parts|:
+          1. If |part|'s [=urlpattern-part/type=] is "<code>regexp</code>", return false.
+
+              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+
+      1. Return true.
+  </section>
+
+  <section algorithm>
+    <h3 id="get-router-source-algorithm"><dfn>GetRouterSource</dfn></h3>
+      : Input
+      :: |rules|, a list of {{RouterRule}}
+      :: |request|, a [=/request=]
+      : Output
+      :: {{RouterSourceEnum}} or null
+
+      1. [=list/For each=] |rule| of |rules|:
+          1. If running [=urlpattern/match=] with |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated [=URLPattern=] and |request|'s [=request/URL=] returns null, [=continue=].
+          1. Return |rule|'s {{RouterRule/source}}.
+      1. Return null.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3238,7 +3238,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exiss=], Return false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], Return false.
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
       1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=], then return false.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -136,6 +136,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
     type: dfn
         text: match; for: urlpattern; url: match
+        text: building a urlpattern from a webidl value; for: urlpattern; url: building-a-urlpattern-from-a-webidl-value
 
 </pre>
 
@@ -3234,7 +3235,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of [=URLPattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
+      1. Let |pattern| be the result of [=urlpattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3108,7 +3108,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
-          1. If running [=GetRouterSource=] algorithm with <a>active worker</a> and |request| returns "network", return null.
+          1. If running [=GetRouterSource=] with |registration|'s <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3226,7 +3226,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{URLPattern}}
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
-      1. Return the result of [=building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
+      1. Return the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -136,7 +136,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
     type: dfn
         text: match; for: urlpattern; url: match
-        text: building a urlpattern from a webidl value; for: urlpattern; url: building-a-urlpattern-from-a-webidl-value
 
 </pre>
 
@@ -1578,7 +1577,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
 
       {{InstallEvent/addRoutes(rules)}} registers this service worker the rules to offload simple tasks that the fetch handler does.
 
-      <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method *must* run these steps:
+      The <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method steps are:
 
         1. Let |routerRules| be a list of {{RouterRule}} dictionaries.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
@@ -3225,13 +3224,13 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
   <section algorithm>
     <h3 id="parse-urlpattern-algorithm"><dfn>ParseURLPattern</dfn></h3>
       : Input
-      :: |rawPattern|, a {{RouterCondition/urlPattern}}"
+      :: |rawPattern|, a [=string=]
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: {{URLPattern}}
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
-      1. Return the result of [=urlpattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
+      1. Return the result of [=building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
   </section>
 
   <section algorithm>
@@ -3243,9 +3242,11 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
+      1. If |rule|["{{RouterRule/condition}}"] does not [=map/exist=], return false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
       1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-      1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
+      1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
@@ -3261,10 +3262,12 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-          1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
-          1. Return |rule|'s {{RouterRule/source}}.
+          1. If |rule|["{{RouterRule/condition}}"] does not [=map/exist=], continue.
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+              1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+              1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+              1. Return |rule|'s {{RouterRule/source}}.
       1. Return null.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -212,7 +212,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
 
     A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
 
-    A [=/service worker=] has an associated <dfn>static router rules object</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially unset.
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
@@ -1587,7 +1587,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
         1.  For each |rule| of |rules|:
             1. If running [=VerifyRouterRule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
             1. Append |rule| to |routerRules|.
-        1. Set [=/service worker=]'s [=static router rules object=] to |routerRules|.
+        1. Set [=/service worker=]'s [=service worker/list of router rules=] to |routerRules|.
 
     </section>
   </section>
@@ -3114,8 +3114,8 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
-      1. Else if |registration|'s <a>active worker</a>'s [=static router rules object=] is set:
-          1. If running [=GetRouterSource=] algorithm with [=static router rules object=] and |request| returns "network", return null.
+      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
+          1. If running [=GetRouterSource=] algorithm with [=service worker/list of router rules=] and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3242,15 +3242,18 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"] does not [=map/exist=], return false.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
-      1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-      1. If |pattern| [=URLPattern/has regexp groups=], then return false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], then:
+          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+          1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
-          Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
-      1. Return true.
+          1. Return true.
+
+          Note: support for other conditions will be implemented here.
+
+      1. Return false.
   </section>
 
   <section algorithm>
@@ -3268,6 +3271,9 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
               1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
               1. Return |rule|'s {{RouterRule/source}}.
+
+          Note: support for other conditions will be implemented here.
+
       1. Return null.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3220,7 +3220,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   <section algorithm>
     <h3 id="parse-urlpattern-algorithm"><dfn>Parse URL Pattern</dfn></h3>
       : Input
-      :: |rawPattern|, a [=string=]
+      :: |rawPattern|, a {{URLPatternCompatible}}
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: {{URLPattern}}

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1573,8 +1573,6 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       enum RouterSource { "network" };
     </pre>
 
-    Each {{RouterCondition/urlPattern}} object has an associated <dfn>URLPattern</dfn>, a {{URLPattern}}, which is initially unset.
-
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
 
@@ -3115,7 +3113,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
-          1. If running [=GetRouterSource=] algorithm with [=service worker/list of router rules=] and |request| returns "network", return null.
+          1. If running [=GetRouterSource=] algorithm with <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.
@@ -3225,6 +3223,18 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
   </section>
 
   <section algorithm>
+    <h3 id="parse-urlpattern-algorithm"><dfn>ParseURLPattern</dfn></h3>
+      : Input
+      :: |rawPattern|, a {{RouterCondition/urlPattern}}"
+      :: |serviceWorker|, a [=/service worker=]
+      : Output
+      :: {{URLPattern}}
+
+      1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
+      1. Return the result of [=urlpattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
+  </section>
+
+  <section algorithm>
     <h3 id="verify-router-rule-algorithm"><dfn>VerifyRouterRule</dfn></h3>
 
       : Input
@@ -3233,27 +3243,27 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
-      1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of [=urlpattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
+      1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
-      1. Set |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated {{URLPattern}} to |pattern|.
       1. Return true.
   </section>
 
   <section algorithm>
     <h3 id="get-router-source-algorithm"><dfn>GetRouterSource</dfn></h3>
       : Input
-      :: |rules|, a list of {{RouterRule}}
+      :: |serviceWorker|, a [=/service worker=]
       :: |request|, a [=/request=]
       : Output
       :: {{RouterSource}} or null
 
-      1. [=list/For each=] |rule| of |rules|:
-          1. If running [=urlpattern/match=] with |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated [=URLPattern=] and |request|'s [=request/URL=] returns null, [=continue=].
+      1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
+          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+          1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. Return |rule|'s {{RouterRule/source}}.
       1. Return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1569,7 +1569,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
     <pre class="idl">
       [Exposed=ServiceWorker]
       interface InstallEvent : ExtendableEvent {
-        Promise&lt;undefined&gt; registerRouter((RouterRule or sequence&lt;RouterRule&gt;) rules);
+        Promise&lt;undefined&gt; addRoutes((RouterRule or sequence&lt;RouterRule&gt;) rules);
       };
 
       dictionary RouterRule {
@@ -1578,24 +1578,24 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       };
 
       dictionary RouterCondition {
-        USVString urlPattern;
+        URLPatternCompatible urlPattern;
       };
 
-      enum RouterSourceEnum { "network" };
+      enum RouterSource { "network" };
     </pre>
 
     Each {{RouterCondition/urlPattern}} object has an associated <dfn>URLPattern</dfn>, a {{URLPattern}}, which is initially unset.
 
     <section>
-      <h4 id="register-router-method">{{InstallEvent/registerRouter(rules)|event.registerRouter(rules)}}</h4>
+      <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
 
-      {{InstallEvent/registerRouter(rules)}} registers this service worker the rules to offload simple tasks that the fetch handler does.
+      {{InstallEvent/addRoutes(rules)}} registers this service worker the rules to offload simple tasks that the fetch handler does.
 
-      <dfn method for="InstallEvent"><code>registerRouter(|rules|)</code></dfn> method *must* run these steps:
+      <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method *must* run these steps:
 
         1. Let |routerRules| be a list of {{RouterRule}} dictionaries.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
-        1.  for each |rule| in |rules|:
+        1.  For each |rule| of |rules|:
             1. If running [=VerifyRouterRule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
             1. Append |rule| to |routerRules|.
         1. Set [=/service worker=]'s [=static router rules object=] to |routerRules|.
@@ -3244,52 +3244,13 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] is the empty string, return false.
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. If |rawPattern| is a [=string=], then:
-        1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
-        1. Set |pattern| to the result of constructing a {{URLPattern}} using the {{URLPattern/URLPattern(input, baseURL)}} constructor steps given |rawPattern| and |baseURL|. If those steps throw, catch the exception and return false.
-      1. Otherwise, if |rawPattern| is {{URLPatternInit}}:
-        1. Set |pattern| to the result of constructing a {{URLPattern}} using the {{URLPattern/URLPattern(input)}} constructor steps given |rawPattern|. If those steps throw, catch the exception and return false.
-      1. Otherwise, return false.
-      1. If running the [=VerifyURLPattern=] algorithm with |pattern| returns false, return false.
+      1. Let |pattern| be the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serivceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
+      1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
+
+          Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+
       1. Set |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated {{URLPattern}} to |pattern|.
-      1. Return true.
-  </section>
-
-  <section algorithm>
-    <h3 id="verify-urlpattern-algorithm"><dfn>VerifyURLPattern</dfn></h3>
-
-    : Input
-    :: |pattern|, a {{URLPattern}}
-    : Output
-    :: a boolean
-
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/protocol component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/username component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/password component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/hostname component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/port component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/pathname component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/search component=] returns false, return false.
-    1. If running the [=VerifyURLPatternComponent=] algorithm with |pattern|'s [=urlpattern/hash component=] returns false, return false.
-    1. Return true.
-  </section>
-
-  <section algorithm>
-    <h3 id="verify-urlpattern-component-algorithm"><dfn>VerifyURLPatternComponent</dfn></h3>
-
-      : Input
-      :: |component|, a [=component=].
-      : Output
-      :: a boolean
-
-      1. Let |parts| be a result of [=urlpattern/parsing=] |component|'s associated [=urlpattern-component/pattern string=].
-      1. [=list/For each=] |part| of |parts|:
-          1. If |part|'s [=urlpattern-part/type=] is "<code>regexp</code>", return false.
-
-              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
-
       1. Return true.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3238,7 +3238,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], Return false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
       1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=], then return false.
@@ -3261,7 +3261,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
           1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
           1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
-          1. Return |rule|'s {{RouterRule/source}}.
+          1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3238,16 +3238,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-          1. If |pattern| [=URLPattern/has regexp groups=], then return false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exiss=], Return false.
+      1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+      1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+      1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
-              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+          Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
-          1. Return true.
-
-      1. Return false.
+      1. Return true.
   </section>
 
   <section algorithm>
@@ -3259,12 +3257,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-          1. If |rule|["{{RouterRule/condition}}"] does not [=map/exist=], continue.
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-              1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
-              1. Return |rule|'s {{RouterRule/source}}.
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], continue.
+          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. Return |rule|'s {{RouterRule/source}}.
 
       1. Return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -135,19 +135,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
     type: dfn
-        text: parse; for: urlpattern; url: parse-a-pattern-string
-        text: component; for: urlpattern; url: component
         text: match; for: urlpattern; url: match
-        text: protocol component; for: urlpattern; url: urlpattern-protocol-component
-        text: username component; for: urlpattern; url: urlpattern-username-component
-        text: password component; for: urlpattern; url: urlpattern-password-component
-        text: hostname component; for: urlpattern; url: urlpattern-hostname-component
-        text: port component; for: urlpattern; url: urlpattern-port-component
-        text: pathname component; for: urlpattern; url: urlpattern-pathname-component
-        text: search component; for: urlpattern; url: urlpattern-search-component
-        text: hash component; for: urlpattern; url: urlpattern-hash-component
-        text: pattern string; for: urlpattern-component; url: component-pattern-string
-        text: type; for: urlpattern-part; url: part-type
 
 </pre>
 
@@ -1574,7 +1562,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
 
       dictionary RouterRule {
         required RouterCondition condition;
-        required RouterSourceEnum source;
+        required RouterSource source;
       };
 
       dictionary RouterCondition {
@@ -3246,7 +3234,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
+      1. Let |pattern| be the result of [=URLPattern/building a URLPattern from a WebIDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=]. If this throws an exception, catch it and return false.
       1. If |pattern| [=URLPattern/has regexp groups=] returns true, return false.
 
           Note: Since running a user-defined regular expression has a security concern, it is prohibited.
@@ -3261,7 +3249,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       :: |rules|, a list of {{RouterRule}}
       :: |request|, a [=/request=]
       : Output
-      :: {{RouterSourceEnum}} or null
+      :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |rules|:
           1. If running [=urlpattern/match=] with |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"]'s associated [=URLPattern=] and |request|'s [=request/URL=] returns null, [=continue=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3242,7 +3242,7 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], then:
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
           1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
           1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
           1. If |pattern| [=URLPattern/has regexp groups=], then return false.
@@ -3250,8 +3250,6 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Return true.
-
-          Note: support for other conditions will be implemented here.
 
       1. Return false.
   </section>
@@ -3271,8 +3269,6 @@ spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
               1. Let |pattern| be the result of running <a>ParseURLPattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=urlpattern/match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
               1. Return |rule|'s {{RouterRule/source}}.
-
-          Note: support for other conditions will be implemented here.
 
       1. Return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1580,7 +1580,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1.  For each |rule| of |rules|:
             1. If running [=Verify Router Rule=] algorithm with |rule| and [=/service worker=] returns false, <a>throw</a> a <code>TypeError</code>.
             1. Append |rule| to |routerRules|.
-        1. Set [=/service worker=]'s [=service worker/list of router rules=] to |routerRules|.
+        1. Set the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=service worker/list of router rules=] to |routerRules|.
 
     </section>
   </section>


### PR DESCRIPTION
I used to work on the specification update to support the ServiceWorker static routing API
(https://github.com/WICG/service-worker-static-routing-api) https://github.com/w3c/ServiceWorker/pull/1686

However, I accidentally closed it by force-sync to the ServiceWorker specification's repository HEAD.

This CL is for reviving it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1.html" title="Last updated on Dec 6, 2023, 9:42 AM UTC (acdd79d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/1/4711a07...acdd79d.html" title="Last updated on Dec 6, 2023, 9:42 AM UTC (acdd79d)">Diff</a>