### PR TITLE
Fix router rule initialization

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -207,7 +207,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
 
-    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially an empty [=list=].
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3107,7 +3107,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
-      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
+      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
           1. If running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:


### PR DESCRIPTION
The `list of router rules` of `service worker` is currently initialized as if it is a flag, but it is actually a list.
This PR fix this bug.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/azaika/ServiceWorker/pull/3.html" title="Last updated on Dec 15, 2023, 5:10 AM UTC (0d6d4e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/3/745eeeb...azaika:0d6d4e1.html" title="Last updated on Dec 15, 2023, 5:10 AM UTC (0d6d4e1)">Diff</a>