### PR TITLE
Add "cache" source support.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3120,7 +3120,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Else:
                   1. Let |requestResponse| be the first element of |requestResponses|.
                   1. Let |response| be |requestResponse|'s response.
-                  1. Let |settingsObject| be a new [=environment settings object=].
+                  1. Let |settingsObject| be a copy of [=relevant settings object=].
                   1. Set |registration|'s <a>active worker</a>'s <a>script resource</a>'s [=script resource/policy container=] to |settingsObject|'s [=environment settings object/policy container=]
                   1. Let |cacheOrigin| be |registration|'s [=/storage key=]'s [=/origin=].
                   1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |cacheOrigin|, |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3111,8 +3111,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
           1. Let |source| be a result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
-          1. If |source| is "network", return null.
-          1. Else if |source| is "cache":
+          1. If |source| is {{RouterSource/"network"}}, return null.
+          1. Else if |source| is {{RouterSource/"cache"}}, then:
               1. Let |cache promise| be a result of {{cache/matchAll(|request|, {})}}
               1. [=Upon fulfillment=] of |cache promise| with |cache response|:
                   1. If |cache response| is not a {{Response}} object, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1565,7 +1565,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         URLPatternCompatible urlPattern;
       };
 
-      enum RouterSource { "fetch-event", "network" };
+      enum RouterSource { "cache", "fetch-event", "network" };
     </pre>
 
     <section>
@@ -3110,7 +3110,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
-          1. If running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request| returns "network", return null.
+          1. Let |source| be a result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. If |source| is "network", return null.
+          1. Else if |source| is "cache":
+              1. Let |cache promise| be a result of {{cache/matchAll(|request|, {})}}
+              1. [=Upon fulfillment=] of |cache promise| with |cache response|:
+                  1. If |cache response| is not a {{Response}} object, return null.
+                  1. Set |response| to |cache response|.
+                  1. Return |response|
+              1. Return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3115,12 +3115,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Let |source| be a result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. If |source| is {{RouterSource/"network"}}, return null.
           1. Else if |source| is {{RouterSource/"cache"}}, then:
-              1. Let |cache promise| be a result of {{cache/matchAll(|request|, {})}}
-              1. [=Upon fulfillment=] of |cache promise| with |cache response|:
-                  1. If |cache response| is not a {{Response}} object, return null.
-                  1. Set |response| to |cache response|.
-                  1. Return |response|
-              1. Return null.
+              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
+              1. If |requestResponses| is an empty [=list=], return null.
+              1. Else:
+                  1. Let |requestResponse| be the first element of |requestResponses|.
+                  1. Let |response| be a copy of |requestResponse|'s response.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3120,10 +3120,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Else:
                   1. Let |requestResponse| be the first element of |requestResponses|.
                   1. Let |response| be |requestResponse|'s response.
-                  1. Let |settingsObject| be a copy of [=relevant settings object=].
-                  1. Set |registration|'s <a>active worker</a>'s <a>script resource</a>'s [=script resource/policy container=] to |settingsObject|'s [=environment settings object/policy container=]
-                  1. Let |cacheOrigin| be |registration|'s [=/storage key=]'s [=/origin=].
-                  1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |cacheOrigin|, |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                   1. Return |response|.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3112,14 +3112,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
-          1. Let |source| be a result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. If |source| is {{RouterSource/"network"}}, return null.
           1. Else if |source| is {{RouterSource/"cache"}}, then:
               1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
               1. If |requestResponses| is an empty [=list=], return null.
               1. Else:
                   1. Let |requestResponse| be the first element of |requestResponses|.
-                  1. Let |response| be a copy of |requestResponse|'s response.
+                  1. Let |response| be |requestResponse|'s response.
                   1. Let |settingsObject| be a new [=environment settings object=].
                   1. Set |registration|'s <a>active worker</a>'s <a>script resource</a>'s [=script resource/policy container=] to |settingsObject|'s [=environment settings object/policy container=]
                   1. Let |cacheOrigin| be |registration|'s [=/storage key=]'s [=/origin=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3120,6 +3120,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Else:
                   1. Let |requestResponse| be the first element of |requestResponses|.
                   1. Let |response| be a copy of |requestResponse|'s response.
+                  1. Let |settingsObject| be a new [=environment settings object=].
+                  1. Set |registration|'s <a>active worker</a>'s <a>script resource</a>'s [=script resource/policy container=] to |settingsObject|'s [=environment settings object/policy container=]
+                  1. Let |cacheOrigin| be |registration|'s [=/storage key=]'s [=/origin=].
+                  1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |cacheOrigin|, |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                  1. Return |response|.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.


### PR DESCRIPTION
The ServiceWorker static routing API allows to look up a response from the cache storage directly upon the rule.  This is a specification update to support that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/4.html" title="Last updated on Jan 26, 2024, 11:00 AM UTC (c6628d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/4/9709650...c6628d1.html" title="Last updated on Jan 26, 2024, 11:00 AM UTC (c6628d1)">Diff</a>