### PR TITLE
Add runningStatus condition support.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3266,14 +3266,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
+
+          Note: if there are multiple conditions in a rule, all conditions should be matched to return the source.
+
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
               1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
-              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], continue.
-              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], continue.
+              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].
+              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], [=continue=].
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3251,9 +3251,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] is neither of  {{RunningStatus/"running"}} nor {{RunningStatus/"not-running"}}, return false.
-          1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
 
@@ -3267,7 +3265,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
 
-          Note: if there are multiple conditions in a rule, all conditions should be matched to return the source.
+          Note: if there are multiple conditions in a rule, all conditions will be matched to return the source.
 
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,8 +1563,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
+        RunningStatus runningStatus;
       };
 
+      enum RunningStatus { "running", "not-running" };
       enum RouterSource { "fetch-event", "network" };
     </pre>
 
@@ -3240,14 +3242,19 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
-      1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-      1. If |pattern| [=URLPattern/has regexp groups=], then return false.
+      1. Let |hasCondition| be false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+          1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
-          Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
-      1. Return true.
+          1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] is neither of  {{RunningStatus/"running"}} nor {{RunningStatus/"not-running"}}, return false.
+          1. Set |hasCondition| to true.
+      1. Return |hasCondition|.
   </section>
 
   <section algorithm>
@@ -3259,10 +3266,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], continue.
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+              1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
+              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], continue.
+              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], continue.
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.


### PR DESCRIPTION
The ServiceWorker static routing API has a condition on a ServiceWorker running status. This is a specification update to support that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/5.html" title="Last updated on Jan 18, 2024, 2:37 AM UTC (8a6887b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/5/a44f9a4...8a6887b.html" title="Last updated on Jan 18, 2024, 2:37 AM UTC (8a6887b)">Diff</a>