### PR TITLE
Add request{Method,Mode,Destination} support.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,6 +1563,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
+        USVString requestMethod;
+        RequestMode requestMode;
+        RequestDestination requestDestination;
         RunningStatus runningStatus;
       };
 
@@ -3251,6 +3254,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
       1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
@@ -3271,6 +3277,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
               1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
+              1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
+              1. If |request|'s [=request/method] is not |method|, [=continue=]
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
+              1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
+              1. If |request|'s [=request/mode] is not |mode|, [=continue=]
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
+              1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
+              1. If |request|'s [=request/destination] is not |destination|, [=continue=]
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3279,13 +3279,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method] is not |method|, [=continue=]
+              1. If |request|'s [=request/method] is not |method|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
               1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode] is not |mode|, [=continue=]
+              1. If |request|'s [=request/mode] is not |mode|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
               1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination] is not |destination|, [=continue=]
+              1. If |request|'s [=request/destination] is not |destination|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,7 +1563,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
-        USVString requestMethod;
+        ByteString requestMethod;
         RequestMode requestMode;
         RequestDestination requestDestination;
         RunningStatus runningStatus;
@@ -3279,13 +3279,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method] is not |method|, [=continue=].
+              1. If |request|'s [=request/method=] is not |method|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
               1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode] is not |mode|, [=continue=].
+              1. If |request|'s [=request/mode=] is not |mode|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
               1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination] is not |destination|, [=continue=].
+              1. If |request|'s [=request/destination=] is not |destination|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].


### PR DESCRIPTION
The ServiceWorker static routing API has a condition on a request{Method,Mode,Destination}. This is a specification update to support that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/6.html" title="Last updated on Jan 22, 2024, 10:26 AM UTC (b82af95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/6/9709650...b82af95.html" title="Last updated on Jan 22, 2024, 10:26 AM UTC (b82af95)">Diff</a>