### PR TITLE
Add or condition support.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3281,7 +3281,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      Note: if there are multiple conditions, all conditions will be matched to return the source.
+      Note: if there are multiple conditions (e.g. `urlPattern`, `runningStatus`, and `requestMethod` are set), all conditions will be matched to return true.
 
       1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
           1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,11 +3263,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
           1. If |hasCondition| is true, return false.
 
-              Note: For ease of understanding the router rule, the "or" condition is mutual exclusive with other conditions.
+              Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
-          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
-          1. For each |or condition| of |or conditions|:
-              1. If running [=Verify Router Condition=] algorithm with |or condition| and |serviceWorker| returns false, return false.
+          1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |orCondition| of |orConditions|:
+              1. If running [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
@@ -3301,13 +3301,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
           1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
       1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
-          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
-          1. Let |or condition matched| be false.
-          1. For each |or condition| of |or conditions|:
-              1. If running [=Match Router Condition=] algorithm with |or condition|, |serviceWorker| and |request| returns true:
-                1. Set |or condition matched| to true.
-                1. [=break=].
-          1. If |or condition matched| is false, return false.
+          1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |orCondition| of |orConditions|:
+              1. If running [=Match Router Condition=] algorithm with |orCondition|, |serviceWorker| and |request| returns true, then return true.
+          1. Return false.
       1. Return true.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1567,6 +1567,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         RequestMode requestMode;
         RequestDestination requestDestination;
         RunningStatus runningStatus;
+
+        sequence&lt;RouterCondition&gt; _or;
       };
 
       enum RunningStatus { "running", "not-running" };
@@ -1584,7 +1586,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |routerRules| be a copy of |serviceWorker|'s [=list of router rules=].
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1.  For each |rule| of |rules|:
-            1. If running [=Verify Router Rule=] algorithm with |rule| and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
+            1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
         1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSource/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
@@ -3237,28 +3239,76 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="verify-router-rule-algorithm"><dfn>Verify Router Rule</dfn></h3>
+    <h3 id="verify-router-rule-algorithm"><dfn>Verify Router Condition</dfn></h3>
 
       : Input
-      :: |rule|, a {{RouterRule}}
+      :: |condition|, a {{RouterCondition}}
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: a boolean
 
       1. Let |hasCondition| be false.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+      1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
           1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
           1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
+          1. If |hasCondition| is true, return false.
+
+              Note: For ease of understanding the router rule, the "or" condition is mutual exclusive with other conditions.
+
+          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |or condition| of |or conditions|:
+              1. If running [=Verify Router Condition=] algorithm with |or condition| and |serviceWorker| returns false, return false.
+          1. Set |hasCondition| to true.
       1. Return |hasCondition|.
+  </section>
+
+  <section algorithm>
+    <h3 id="match-router-condition-algorithm"><dfn>Match Router Condition</dfn></h3>
+      : Input
+      :: |condition|, a {{RouterCondition}}
+      :: |serviceWorker|, a [=/service worker=]
+      :: |request|, a [=/request=]
+      : Output
+      :: a boolean
+
+      Note: if there are multiple conditions, all conditions will be matched to return the source.
+
+      1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
+      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
+          1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
+          1. If |request|'s [=request/method=] is not |method|, return false.
+      1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], then:
+          1. Let |mode| be |condition|["{{RouterCondition/requestMode}}"].
+          1. If |request|'s [=request/mode=] is not |mode|, return false.
+      1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
+          1. Let |destination| be |condition|["{{RouterCondition/requestDestination}}"].
+          1. If |request|'s [=request/destination=] is not |destination|, return false.
+      1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+          1. Let |runningStatus| be |condition|["{{RouterCondition/runningStatus}}"].
+          1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
+          1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
+      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
+          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
+          1. Let |or condition matched| be false.
+          1. For each |or condition| of |or conditions|:
+              1. If running [=Match Router Condition=] algorithm with |or condition|, |serviceWorker| and |request| returns true:
+                1. Set |or condition matched| to true.
+                1. [=break=].
+          1. If |or condition matched| is false, return false.
+      1. Return true.
   </section>
 
   <section algorithm>
@@ -3270,26 +3320,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-
-          Note: if there are multiple conditions in a rule, all conditions will be matched to return the source.
-
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
-              1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method=] is not |method|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
-              1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode=] is not |mode|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
-              1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination=] is not |destination|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
-              1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
-              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].
-              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], [=continue=].
+          1. If running [=Match Router Condition=] with |rule|["{{RouterRule/condition}}"], |serviceWorker| and |request| returns false, [=continue=].
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.


### PR DESCRIPTION
The ServiceWorker static routing API has a or conditional syntax. This is a specification update to support that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/7.html" title="Last updated on Jan 25, 2024, 7:06 AM UTC (d331f41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/7/9c57f5f...d331f41.html" title="Last updated on Jan 25, 2024, 7:06 AM UTC (d331f41)">Diff</a>