### PR TITLE
Add cacheName support.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1571,8 +1571,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         sequence&lt;RouterCondition&gt; _or;
       };
 
+      typedef (RouterSourceDict or RouterSourceEnum) RouterSource;
+
+      dictionary RouterSourceDict {
+        DOMString cacheName;
+      };
+
       enum RunningStatus { "running", "not-running" };
-      enum RouterSource { "cache", "fetch-event", "network" };
+      enum RouterSourceEnum { "cache", "fetch-event", "network" };
     </pre>
 
     <section>
@@ -1588,7 +1594,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1.  For each |rule| of |rules|:
             1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
-        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSource/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
+        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
 
     </section>
@@ -3136,15 +3142,18 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
       1. If |activeWorker|'s [=service worker/list of router rules=] is [=list/is not empty=]:
           1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
-          1. If |source| is {{RouterSource/"network"}}, return null.
-          1. Else if |source| is {{RouterSource/"cache"}}, then:
-              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
-              1. If |requestResponses| is an empty [=list=], return null.
-              1. Else:
-                  1. Let |requestResponse| be the first element of |requestResponses|.
-                  1. Let |response| be |requestResponse|'s response.
-                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
-                  1. Return |response|.
+          1. If |source| is {{RouterSourceEnum/"network"}}, return null.
+          1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
+              1. [=map/For each=] |cacheName| &#x2192; |cache| of the [=relevant name to cache map=]:
+                  1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] does not match |cacheName|, [=continue=].
+                  1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}},and |cache|.
+                  1. If |requestResponses| is an empty [=list=], return null.
+                  1. Else:
+                      1. Let |requestResponse| be the first element of |requestResponses|.
+                      1. Let |response| be |requestResponse|'s response.
+                      1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                      1. Return |response|.
+              1. Return null.
       1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3146,7 +3146,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
               1. [=map/For each=] |cacheName| &#x2192; |cache| of the [=relevant name to cache map=]:
                   1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] does not match |cacheName|, [=continue=].
-                  1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}},and |cache|.
+                  1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.
                   1. If |requestResponses| is an empty [=list=], return null.
                   1. Else:
                       1. Let |requestResponse| be the first element of |requestResponses|.


### PR DESCRIPTION
With this change, cacheName is supported.  It means that if there is multiple cache storage and developers want to choose which storage to use, they can specify the storage by cacheName.

This change also contains some fixes of the behavior.  In the previous PR, I misunderstood the cache match
behavior, and it actually might not match multiple cache storage's data.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 6:12 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyoshisatoyanagisawa%2FServiceWorker%2Fdbe3245224d6477acf76bfa5ebc25ec9a681634f%2Fdocs%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20yoshisatoyanagisawa/ServiceWorker%239.)._
</details>
