### PR TITLE
Add `race-network-and-fetch-handler` option

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1081,7 +1081,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=requests=] and the [=map/values=] are [=race response=]. It is initially unset.
 
-    A <dfn export id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has [=/response=], or "<code>pending</code>" as an [=struct/item=].
+    A <dfn id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has a <dfn for="race response">value</dfn>, which is a [=/response=], "<code>pending</code>", or null.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -3121,7 +3121,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
-      1. Let |raceResponse| be null.
+      1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is null.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
@@ -3160,16 +3160,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
-              1. Set |raceResponse| to "<code>pending</code>".
+              1. Set |raceResponse|'s [=race response/value=] to "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
-                          1. Set |raceResponse| to |raceNetworkRequestResponse|.
+                          1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
-                      1. Otherwise, set |raceResponse| to a [=network error=].
+                      1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
               1. [=If aborted=] and |raceFetchController| is not null, then:
                   1. [=fetch controller/abort=] |raceFetchController|.
-                  1. Set |raceResponse| to null.
+                  1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
                   1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
@@ -3242,7 +3242,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
-          1. If |raceResponse| is not null, then:
+          1. If |raceResponse|'s [=race response/value=] is not null, then:
               1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
               1. [=map/Set=] |map|[|request|] to |raceResponse|.
           1. [=Queue a task=] |task| to run the following substeps:
@@ -3286,9 +3286,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
               2. Return a [=network error=].
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
-          1. If |raceResponse| is not null, then:
-              1. Wait until |raceResponse| is not "<code>pending</code>"
-              1. If |raceResponse| is [=/response=], return |raceResponse|.
+          1. If |raceResponse|'s [=race response/value=] is not null, then:
+              1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>"
+              1. If |raceResponse|'s [=race response/value=] is [=/response=], return |raceResponse|'s [=race response/value=].
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
@@ -3933,7 +3933,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Input
       :: |request|, a [=request=]
       : Output
-      :: a [=race response=].
+      :: a [=/response=], or null.
 
       1. If |request|'s [=request/reserved client=] is null, return null.
       1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
@@ -3944,8 +3944,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |map|[|request|] [=map/exist=], then:
         1. Let |entry| be |map|[|request|].
         1. [=map/Remove=] |map|[|request|].
-        1. Return |entry|.
-      1. Otherwise, return null.
+        1. Wait until |entry|'s [=race response/value=] is not "<code>pending</code>"
+        1. If |entry|'s [=race response/value=] is [=/response=], return |entry|'s [=race response/value=].
+      1. Return null.
   </section>
 </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3116,6 +3116,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |client| be |request|'s [=request/client=].
       1. Let |reservedClient| be |request|'s [=request/reserved client=].
       1. Let |preloadResponse| be a new [=promise=].
+      1. Let |raceFetchController| be null.
       1. Let |workerRealm| be null.
       1. Let |eventHandled| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
@@ -3158,13 +3159,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
               Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of |e|'s [=FetchEvent/potential response=], or the fallback request.
 
-              1. Let |raceFetchController| be null.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
 
                       To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
                           1. If |response| is not null, or |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
-                            1. terminate these substeps.
+                            1. Terminate these substeps.
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
                             1. Set |response| to |raceNetworkRequestResponse|.
                             1. Return |response|.
@@ -3235,7 +3235,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
-              1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
+              1. If |response| is not null, then:
+                  1. Set |response|'s [=response/service worker timing info=] to |timingInfo|.
+                  1. If |raceFetchController| is not null, then:
+                      1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+                      1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
                   1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3260,8 +3260,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
-              1. If |response| is not null, then:
-                  1. Set |response|'s [=response/service worker timing info=] to |timingInfo|.
+              1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
                   1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3158,14 +3158,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
+              1. Set |raceResponse| to "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
-                      1. Set |raceResponse| to [=a new promise=].
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
-                          1. [=Resolve=] |raceResponse| with |raceNetworkRequestResponse|.
+                          1. Set |raceResponse| to |raceNetworkRequestResponse|.
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
-                      1. Otherwise, [=reject=] |raceResponse| with a `TypeError`.
-              1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
+                      1. Otherwise, set |raceResponse| to a `TypeError`.
+              1. [=If aborted=] and |raceFetchController| is not null, then:
+                  1. [=fetch controller/abort=] |raceFetchController|.
+                  1. Set |raceResponse| to null.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
                   1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
@@ -3208,7 +3210,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=]
       :: |reservedClient|, a [=request/reserved client=]
       :: |preloadResponse|, a [=promise=]
-      :: |raceResponse|, a [=promise=]
+      :: |raceResponse|, a null, "<code>pending</code>" or [=/response=]
       : Output
       :: a [=/response=]
 
@@ -3241,7 +3243,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |raceResponse| is not null, then:
               1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
               1. [=map/Set=] |map|[|request|] to |raceResponse|.
-              1. Set |request|'s [=request/service-workers race token=] to |token|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
@@ -3284,9 +3285,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               2. Return a [=network error=].
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
           1. If |raceResponse| is not null, then:
-              1. [=promise/React=] to |raceResponse|:
-                  1. If |raceResponse| was fulfilled with value |v|, return |v|.
-                  1. If |raceResponse| was rejected, return [=network error=].
+              1. Wait until |raceResponse| is not "<code>pending</code>"
+              1. If |raceResponse| is [=/response=], return |raceResponse|.
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3119,6 +3119,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
+      1. Let |raceResponse| be null.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
@@ -3162,11 +3163,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |raceFetchController| be null.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
-                      1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], [=queue/enqueue=] |raceNetworkRequestResponse| to |queue|.
+                      1. Set |raceResponse| to [=a new promise=].
+                      1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
+                          1. Resolve |raceResponse| with |raceNetworkRequestResponse|.
+                          1. [=queue/enqueue=] |raceNetworkRequestResponse| to |queue|.
+                      1. Otherwise, reject |raceResponse| with a `TypeError`.
               1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
-                  1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
+                  1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                   1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
                   1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
               1. Wait until |queue| is not empty.
@@ -3193,7 +3198,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
+      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
   </section>
 
   <section algorithm>
@@ -3206,6 +3211,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=].
       :: |reservedClient|, a [=request/reserved client=].
       :: |preloadResponse| a [=promise=].
+      :: |raceResponse| a [=promise=].
       : Output
       :: a [=/response=]
 
@@ -3276,6 +3282,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
               2. Return a [=network error=].
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
+          1. If |raceResponse| is not null, then:
+              1. [=promise/React=] to |raceResponse|:
+                  1. If |raceResponse| was fulfilled with value |v|, return |v|.
+                  1. If |raceResponse| was rejected, return [=network error=].
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3155,13 +3155,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of {{FetchEvent}}'s [=FetchEvent/potential response=], or the fallback request.
 
               1. Let |queue| be an empty [=queue=] of [=/response=].
-              1. Run the following substeps [=in parallel=]:
-                  1. Let |raceFetchController| to the result of [=Fetch|fetching=] |request|.
+              1. Let |raceFetchController| be null.
+              1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
                   1. To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
                       1. If |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
                           1. Terminate these substeps.
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
+              1. [=If aborted=], then:
+                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+                  1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
               1. Run the following substeps [=in parallel=]:
                   1. Resolve |preloadResponse| with undefined.
                   1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
@@ -3196,7 +3200,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="create-fetch-event-and-dispatch"><dfn>Create Fetch Event and Dispatch</dfn><h3>
+    <h3 id="create-fetch-event-and-dispatch-algorithm"><dfn>Create Fetch Event and Dispatch</dfn></h3>
       : Input
       :: |request|, a [=/request=]
       :: |registration|, a [=/service worker registration=]

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1079,7 +1079,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are strings and the [=map/values=] are <a>promises</a>. It is initially unset.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -3241,6 +3241,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
+          1. If |raceResponse| is not null, then:
+              1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
+              1. Let |token| be the result of [=generating a random UUID=].
+              1. [=map/Set=] |map|[|token|] to |raceResponse|.
+              1. Set |request|'s [=request/service-workers race token=] to |token|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
@@ -3922,6 +3927,29 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If [=Is Async Module=] for |moduleMap|[|url|]'s [=script/record=], |moduleMap|, |base|, and |seen| is true, then:
                   1. Return true.
       1. Return false.
+  </section>
+
+  <section algorithm>
+    <h3 id="lookup-race-response-algorithm"><dfn export>Lookup Race Response</dfn></h3>
+
+      : Input
+      :: |key|, a string
+      :: |reservedClient|, [=request/reserved client=]
+      :: |url|, [=request/url=]
+      : Output
+      :: a [=promise=].
+
+      1. If |reservedClient| is null, return null.
+      1. Let |storage key| be the result of running [=obtain a storage key=] given |reservedClient|.
+      1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |url|.
+      1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
+      1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
+      1. If |map|[|key|] [=map/exist=], then:
+        1. Let |entry| be |map|[|key|].
+        1. [=map/Remove=] |map|[|key|].
+        1. Return |entry|.
+      1. Otherwise, return null.
   </section>
 </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3157,21 +3157,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
-                  1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
-                  1. To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
-                      1. If |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
-                          1. Terminate these substeps.
-                      1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
-                          1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
-              1. [=If aborted=] and |raceFetchController| is not null, then:
-                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-                  1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
+                  1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
+                      1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], [=queue/enqueue=] |raceNetworkRequestResponse| to |queue|.
+                  1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/Abort=] |raceFetchController|.
+              1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
-                  1. Resolve |preloadResponse| with undefined.
                   1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
-                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, then:
-                      1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-                      1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
+                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/Abort=] |raceFetchController|.
                   1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
               1. Wait until |queue| is not empty.
               1. Set |response| to the result of [=dequeue=] |queue|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3161,6 +3161,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
               1. Set |raceResponse|'s [=race response/value=] to "<code>pending</code>".
+              1. [=map/Set=] |activeWorker|'s [=service worker/global object=]'s [=race response map=][|request|] to |raceResponse|.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
@@ -3226,6 +3227,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
+      1. Let |raceResponseMap| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
@@ -3242,9 +3244,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
-          1. If |raceResponse|'s [=race response/value=] is not null, then:
-              1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
-              1. [=map/Set=] |map|[|request|] to |raceResponse|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
@@ -3281,6 +3280,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. Wait for |task| to have executed or for |handleFetchFailed| to be true.
       1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+      1. If |raceResponseMap|[|request|] [=map/exists=], [=map/remove=] |raceResponseMap|[|request|].
       1. If |respondWithEntered| is false, then:
           1. If |eventCanceled| is true, then:
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
@@ -3931,7 +3931,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <h3 id="lookup-race-response-algorithm"><dfn export>Lookup Race Response</dfn></h3>
 
       : Input
-      :: |request|, a [=request=]
+      :: |request|, a [=/request=]
       : Output
       :: a [=/response=], or null.
 
@@ -3941,7 +3941,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
       1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
       1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
-      1. If |map|[|request|] [=map/exist=], then:
+      1. If |map|[|request|] [=map/exists=], then:
         1. Let |entry| be |map|[|request|].
         1. [=map/Remove=] |map|[|request|].
         1. Wait until |entry|'s [=race response/value=] is not "<code>pending</code>"

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1578,7 +1578,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
 
       enum RunningStatus { "running", "not-running" };
-      enum RouterSourceEnum { "cache", "fetch-event", "network", "race-network-and-fetch-handler" };
+      enum RouterSourceEnum {
+        "cache",
+        "fetch-event",
+        "network",
+        "race-network-and-fetch-handler"
+      };
     </pre>
 
     <section>
@@ -3106,9 +3111,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |controller|, a [=fetch controller=]
       :: |useHighResPerformanceTimers|, a boolean
       : Output
-      :: |response|, a [=/response=]
+      :: a [=/response=]
 
-      1. Let |response| be null.
       1. Let |registration| be null.
       1. Let |client| be |request|'s [=request/client=].
       1. Let |reservedClient| be |request|'s [=request/reserved client=].
@@ -3159,15 +3163,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], [=queue/enqueue=] |raceNetworkRequestResponse| to |queue|.
-                  1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/Abort=] |raceFetchController|.
+              1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
                   1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
-                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/Abort=] |raceFetchController|.
+                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
                   1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
               1. Wait until |queue| is not empty.
-              1. Set |response| to the result of [=dequeue=] |queue|.
-              1. Return |response|.
+              1. Return the result of [=dequeue=] |queue|.
       1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set, then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
@@ -3190,8 +3193,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Set |response| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
-      1. Retrun |response|.
+      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
   </section>
 
   <section algorithm>
@@ -3205,8 +3207,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |reservedClient|, a [=request/reserved client=].
       :: |preloadResponse| a [=promise=].
       : Output
-      :: |response|, a [=/response=]
+      :: a [=/response=]
 
+      1. Let |response| be null.
       1. Let |eventCanceled| be false.
       1. Let |client| be |request|'s [=request/client=].
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1079,7 +1079,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are strings and the [=map/values=] are <a>promises</a>. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=requests=] and the [=map/values=] are <a>promises</a>. It is initially unset.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -3162,13 +3162,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. Set |raceResponse| to [=a new promise=].
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
-                          1. Resolve |raceResponse| with |raceNetworkRequestResponse|.
-                          1. [=queue/enqueue=] |raceNetworkRequestResponse| to |queue|.
-                      1. Otherwise, reject |raceResponse| with a `TypeError`.
+                          1. [=Resolve=] |raceResponse| with |raceNetworkRequestResponse|.
+                          1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
+                      1. Otherwise, [=reject=] |raceResponse| with a `TypeError`.
               1. [=If aborted=] and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
-                  1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
+                  1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                   1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
                   1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
               1. Wait until |queue| is not empty.
@@ -3204,11 +3204,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |request|, a [=/request=]
       :: |registration|, a [=/service worker registration=]
       :: |useHighResPerformanceTimers|, a boolean
-      :: |timingInfo|, a [=service worker timing info=].
-      :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=].
-      :: |reservedClient|, a [=request/reserved client=].
-      :: |preloadResponse| a [=promise=].
-      :: |raceResponse| a [=promise=].
+      :: |timingInfo|, a [=service worker timing info=]
+      :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=]
+      :: |reservedClient|, a [=request/reserved client=]
+      :: |preloadResponse|, a [=promise=]
+      :: |raceResponse|, a [=promise=]
       : Output
       :: a [=/response=]
 
@@ -3240,8 +3240,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
           1. If |raceResponse| is not null, then:
               1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
-              1. Let |token| be the result of [=generating a random UUID=].
-              1. [=map/Set=] |map|[|token|] to |raceResponse|.
+              1. [=map/Set=] |map|[|request|] to |raceResponse|.
               1. Set |request|'s [=request/service-workers race token=] to |token|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
@@ -3930,21 +3929,19 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <h3 id="lookup-race-response-algorithm"><dfn export>Lookup Race Response</dfn></h3>
 
       : Input
-      :: |key|, a string
-      :: |reservedClient|, [=request/reserved client=]
-      :: |url|, [=request/url=]
+      :: |request|, a [=request=]
       : Output
       :: a [=promise=].
 
-      1. If |reservedClient| is null, return null.
-      1. Let |storage key| be the result of running [=obtain a storage key=] given |reservedClient|.
+      1. If |request|'s [=request/reserved client=] is null, return null.
+      1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
       1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |url|.
       1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
       1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
       1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
-      1. If |map|[|key|] [=map/exist=], then:
-        1. Let |entry| be |map|[|key|].
-        1. [=map/Remove=] |map|[|key|].
+      1. If |map|[|request|] [=map/exist=], then:
+        1. Let |entry| be |map|[|request|].
+        1. [=map/Remove=] |map|[|request|].
         1. Return |entry|.
       1. Otherwise, return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3156,9 +3156,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Return |response|.
               1. Return null.
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
-
-              Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of {{FetchEvent}}'s [=FetchEvent/potential response=], or the fallback request.
-
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3163,12 +3163,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                           1. Terminate these substeps.
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
-              1. [=If aborted=], then:
+              1. [=If aborted=] and |raceFetchController| is not null, then:
                   1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
                   1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
               1. Run the following substeps [=in parallel=]:
                   1. Resolve |preloadResponse| with undefined.
                   1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
+                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, then:
+                      1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+                      1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
                   1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
               1. Wait until |queue| is not empty.
               1. Set |response| to the result of [=dequeue=] |queue|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3108,17 +3108,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: |response|, a [=/response=]
 
-      1. Let |handleFetchFailed| be false.
-      1. Let |respondWithEntered| be false.
-      1. Let |eventCanceled| be false.
       1. Let |response| be null.
       1. Let |registration| be null.
       1. Let |client| be |request|'s [=request/client=].
       1. Let |reservedClient| be |request|'s [=request/reserved client=].
       1. Let |preloadResponse| be a new [=promise=].
-      1. Let |raceFetchController| be null.
       1. Let |workerRealm| be null.
-      1. Let |eventHandled| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
@@ -3159,19 +3154,22 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
               Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of {{FetchEvent}}'s [=FetchEvent/potential response=], or the fallback request.
 
-              1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
-                  1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
-
-                      To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
-                          1. If |response| is not null, or |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
-                            1. Terminate these substeps.
-                          1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
-                            1. Set |response| to |raceNetworkRequestResponse|.
-                            1. Return |response|.
-              1. [=If aborted=], then:
-                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-                  1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
-      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set, and |raceFetchController| is null then:
+              1. Let |queue| be an empty [=queue=] of [=/response=].
+              1. Run the following substeps [=in parallel=]:
+                  1. Let |raceFetchController| to the result of [=Fetch|fetching=] |request|.
+                  1. To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
+                      1. If |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
+                          1. Terminate these substeps.
+                      1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
+                          1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
+              1. Run the following substeps [=in parallel=]:
+                  1. Resolve |preloadResponse| with undefined.
+                  1. Let |fetchHandlerResponse| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
+                  1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
+              1. Wait until |queue| is not empty.
+              1. Set |response| to the result of [=dequeue=] |queue|.
+              1. Return |response|.
+      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set, then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
@@ -3193,6 +3191,29 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
+      1. Set |response| to the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, and |preloadResponse|.
+      1. Retrun |response|.
+  </section>
+
+  <section algorithm>
+    <h3 id="create-fetch-event-and-dispatch"><dfn>Create Fetch Event and Dispatch</dfn><h3>
+      : Input
+      :: |request|, a [=/request=]
+      :: |registration|, a [=/service worker registration=]
+      :: |useHighResPerformanceTimers|, a boolean
+      :: |timingInfo|, a [=service worker timing info=].
+      :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=].
+      :: |reservedClient|, a [=request/reserved client=].
+      :: |preloadResponse| a [=promise=].
+      : Output
+      :: |response|, a [=/response=]
+
+      1. Let |eventCanceled| be false.
+      1. Let |client| be |request|'s [=request/client=].
+      1. Let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. Let |eventHandled| be null.
+      1. Let |handleFetchFailed| be false.
+      1. Let |respondWithEntered| be false.
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
@@ -3237,9 +3258,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
               1. If |response| is not null, then:
                   1. Set |response|'s [=response/service worker timing info=] to |timingInfo|.
-                  1. If |raceFetchController| is not null, then:
-                      1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-                      1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
                   1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3157,7 +3157,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Return null.
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
 
-              Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of |e|'s [=FetchEvent/potential response=], or the fallback request.
+              Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of {{FetchEvent}}'s [=FetchEvent/potential response=], or the fallback request.
 
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
@@ -3168,10 +3168,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
                             1. Set |response| to |raceNetworkRequestResponse|.
                             1. Return |response|.
-          1. [=If aborted=], then:
-              1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-              1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
-      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
+              1. [=If aborted=], then:
+                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+                  1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
+      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set, and |raceFetchController| is null then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1578,7 +1578,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
 
       enum RunningStatus { "running", "not-running" };
-      enum RouterSourceEnum { "cache", "fetch-event", "network" };
+      enum RouterSourceEnum { "cache", "fetch-event", "network", "race-network-and-fetch-handler" };
     </pre>
 
     <section>
@@ -3154,6 +3154,23 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
+          1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
+
+              Note: In order to avoid duplicated fetches to |request|, the user agent may reuse |raceNetworkRequestResponse| as the result of |e|'s [=FetchEvent/potential response=], or the fallback request.
+
+              1. Let |raceFetchController| be null.
+              1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Set |raceFetchController| to the result of [=Fetch|fetching=] |request|.
+
+                      To [=fetch/processResponse=] for |raceNetworkRequestResponse|, run these substeps:
+                          1. If |response| is not null, or |raceNetworkRequestResponse|'s [=response/type=] is "`error`", then:
+                            1. terminate these substeps.
+                          1. If |raceNetworkRequestResponse|'s [=response/status=] is `200`, then:
+                            1. Set |response| to |raceNetworkRequestResponse|.
+                            1. Return |response|.
+          1. [=If aborted=], then:
+              1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+              1. [=fetch controller/Abort=] |raceFetchController| with |deserializedError|.
       1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3161,7 +3161,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
               1. Set |raceResponse|'s [=race response/value=] to "<code>pending</code>".
-              1. [=map/Set=] |activeWorker|'s [=service worker/global object=]'s [=race response map=][|request|] to |raceResponse|.
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
@@ -3244,6 +3243,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
+          1. If |raceResponse| is not null, [=map/set=] |raceResponseMap|[|request|] to |raceResponse|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1079,7 +1079,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=requests=] and the [=map/values=] are <a>promises</a>. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=requests=] and the [=map/values=] are [=race response=]. It is initially unset.
+
+    A <dfn export id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has [=/response=], or "<code>pending</code>" as an [=struct/item=].
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -3164,7 +3166,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                           1. Set |raceResponse| to |raceNetworkRequestResponse|.
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
-                      1. Otherwise, set |raceResponse| to a `TypeError`.
+                      1. Otherwise, set |raceResponse| to a [=network error=].
               1. [=If aborted=] and |raceFetchController| is not null, then:
                   1. [=fetch controller/abort=] |raceFetchController|.
                   1. Set |raceResponse| to null.
@@ -3210,7 +3212,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=]
       :: |reservedClient|, a [=request/reserved client=]
       :: |preloadResponse|, a [=promise=]
-      :: |raceResponse|, a null, "<code>pending</code>" or [=/response=]
+      :: |raceResponse|, a [=race response=]
       : Output
       :: a [=/response=]
 
@@ -3931,7 +3933,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Input
       :: |request|, a [=request=]
       : Output
-      :: a [=promise=].
+      :: a [=race response=].
 
       1. If |request|'s [=request/reserved client=] is null, return null.
       1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1082,7 +1082,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=requests=] and the [=map/values=] are [=race response=]. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=race response=]. It is initially unset.
 
     A <dfn id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has a <dfn for="race response">value</dfn>, which is a [=/response=], "<code>pending</code>", or null.
 
@@ -3216,7 +3216,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                           1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
                       1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
               1. [=If aborted=] and |raceFetchController| is not null, then:
-                  1. [=fetch controller/abort=] |raceFetchController|.
+                  1. [=fetch controller/Abort=] |raceFetchController|.
                   1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
               1. Resolve |preloadResponse| with undefined.
               1. Run the following substeps [=in parallel=]:
@@ -3336,8 +3336,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               2. Return a [=network error=].
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
           1. If |raceResponse|'s [=race response/value=] is not null, then:
-              1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>"
-              1. If |raceResponse|'s [=race response/value=] is [=/response=], return |raceResponse|'s [=race response/value=].
+              1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>".
+              1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
@@ -3985,7 +3985,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Input
       :: |request|, a [=/request=]
       : Output
-      :: a [=/response=], or null.
+      :: a [=/response=] or null
 
       1. If |request|'s [=request/reserved client=] is null, return null.
       1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].


### PR DESCRIPTION
This PR will add the spec explanation for the `race-network-and-fetch-handler` source in the static routing API.

This option starts the race between the network request and the fetch handler execution, and use the result whichever comes first. Currently the result from the network request is used only when the the response is successfully returned. 

Borrowed sentences mostly from the navigation preload.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorkerForStaticRoutingAPI/pull/10.html" title="Last updated on Feb 16, 2024, 3:59 AM UTC (bf4bdaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/10/59e1de9...sisidovski:bf4bdaf.html" title="Last updated on Feb 16, 2024, 3:59 AM UTC (bf4bdaf)">Diff</a>